### PR TITLE
All with prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Babystore
 
-A tiny (248b gz) wrapper around localStorage with a familiar set of methods.
+A tiny (341b gz) wrapper around localStorage with a familiar set of methods.
 
 ```js
 import { store } from 'babystore';
@@ -20,29 +20,36 @@ p.add('secondItemName', { b: 2 });
 s.has('itemName') // true
 s.has('doesntExist') // false
 
+// prefixed stores are not accessible unless you use the
+// prefixed store or include the prefix
+s.find('secondItemName') // undefined
+s.find('prefixed:secondItemName') // { b: 2 }
+
+// use store.all to get all values in the storage
+store.all() // [ { a: 1 }, { b: 2 } ]
+
 // you can use .delete to remove single items
 p.delete('secondItemName');
 p.find('secondItemName') // undefined
 
-// or use .clear to wipe the entire storage
-s.clear();
+// or use store.nuke to wipe the entire storage
+store.nuke();
 s.find('itemName') // undefined
 
-
-// prefixed stores are not accessible unless you use the
-// prefixed store or manually include the prefix
-s.find('secondItemName') // undefined
-s.find('prefixed:secondItemName') // { b: 2 }
 ```
 
 ### TODO
-- [ ] all() that respects prefixing
 - [ ] keep trimming
-- [ ] use `Promise.resolve().then` to take some methods off the main thread
-    - A potential solution is available at https://github.com/gingerchew/babystore/tree/async-promise-then
 
 ## Changelog
-
+- 0.5.0 (breaking)
+    - the clear and all methods have been removed from babystore instances
+    - nuke and all are the above methods on the store function
+    ```js
+    import { store } from 'store';
+    store.all() // returns all items in localStorage
+    store.nuke() // removes all items in localStorage
+    ```
 - 0.4.0 (breaking) 
     - babystore is now async by default
     - the get handler now returns `async (key, obj) =>` which

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babystore",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Smallest LocalStorage wrapper",
   "main": "src/index.ts",
   "type": "module",

--- a/test/babystore.test.js
+++ b/test/babystore.test.js
@@ -1,6 +1,9 @@
 // @vitest-environment jsdom
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test } from 'vitest';
 import { store } from '../src/index';
+
+beforeEach(() => store.nuke());
+
 describe('store: ', () => {
     test('find, add: ', async () => {
         const val = {
@@ -15,11 +18,9 @@ describe('store: ', () => {
         
         expect(item).toBe(JSON.stringify(val));
         expect(x).toStrictEqual(JSON.parse(s || '{}'));
-        store().clear();
     });
 
     test('prefix: ', async () => {
-        
         const bs = store();
         const bsp = store('prefix:');
 
@@ -37,7 +38,7 @@ describe('store: ', () => {
         expect(await store().find('test')).toBe(null);
     });
 
-    test('clear: ', async () => {
+    test('clear/nuke: ', async () => {
         store().add('test1', { a: '1' });
         store().add('test2', { a: '1' });
         store().add('test3', { a: '1' });
@@ -45,8 +46,8 @@ describe('store: ', () => {
         store().add('test5', { a: '1' });
 
         expect(await store().find('test5')).toStrictEqual({ a: '1'});
-
-        store().clear();
+        
+        store.nuke();
 
         expect(await store().find('test5')).toBe(null); 
     });
@@ -60,11 +61,36 @@ describe('store: ', () => {
 
     test('add to same key: ', async () => {
         const s = store();
-        s.clear();
 
         s.add('item', { a: 1 });
         s.add('item', { b: 2 });
 
         expect(await s.find('item')).toStrictEqual({ a: 1, b: 2 });
+    });
+
+    test('all: ', async () => {
+        const s = store();
+        
+        s.add('item1', { a: 1 });
+        s.add('item2', { a: 2 });
+        s.add('item3', { a: 3 });
+        s.add('item4', { a: 4 });
+        s.add('item5', { a: 5 });
+
+        expect(store.all()).toStrictEqual([{a:1},{a:2},{a:3},{a:4},{a:5}]);
+    });
+
+    test('all prefix: ', async () => {
+        const s = store();
+        const p = store('prefix:');
+
+        s.add('item1', { a: 1 });
+        p.add('item2', { b: 2 });
+        
+        const sAll = store.all();
+        const pAll = store.all('prefix:');
+
+        expect(sAll.length).toBe(2);
+        expect(pAll.length).toBe(1);
     });
 });

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,7 +28,7 @@ type babystore = {
 };
 
 type store = {
-    (key?:string): babystoreFuncs;
+    (): void;
     all: (key?:string) => unknown[];
     nuke: () => void;
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,20 +18,27 @@ type babystoreFuncs = {
     find: (key: string) => any;
     add: (key: string, obj: _UnknownObject) => void;
     delete: (key: string) => void;
-    clear: () => void;
+    // clear: () => void;
     has: (key: string) => boolean;
-    all?: () => any[];
+    // all?: () => any[];
 };
 
 type babystore = {
     [key in keyof babystoreFuncs]: Promise<babystoreFuncs[key]>;
 };
 
+type store = {
+    (key?:string): babystoreFuncs;
+    all: (key?:string) => unknown[];
+    nuke: () => void;
+}
+
 export {
     _UnknownObject,
     PotentialObject,
     ReduceableObject,
     DeepAssign,
+    store,
     babystore,
     babystoreFuncs
 };


### PR DESCRIPTION
Removes methods `all` and `clear` as they were a bit powerful to have on each instance

Adds static methods `all` and `nuke` to the store function

```js
import { store } from 'babystore';

store.all() // lists all items in localStorage
store.nuke() // removes *all* items in localStorage
```

`store.nuke()` is the `dangerouslySetInnerHTML` of babystore

Updates types to account for new static methods